### PR TITLE
src: update example description

### DIFF
--- a/sources/sections/05-date-time-format.adoc
+++ b/sources/sections/05-date-time-format.adoc
@@ -415,7 +415,7 @@ different interpretations.
 1937-01-01T12:00:27.87+00:19:32.130[x-foo-bar][x-baz-bat]
 ----
 
-This timestamp utilizes the generalized format to declare two additional
+This timestamp utilizes the private use namespace to declare two additional
 pieces of information in the suffix that can be interpreted by any
 compatible implementations and ignored otherwise.
 


### PR DESCRIPTION
Rename example description from "generalized format" to "private use
namespace" in order to better explain the `[x-foo-bar]` format.

Fixes: https://github.com/ryzokuken/draft-ryzokuken-datetime-extended/issues/8

/cc @sffc